### PR TITLE
fix(types): housenumber type is now `string`

### DIFF
--- a/.changeset/curvy-ducks-smell.md
+++ b/.changeset/curvy-ducks-smell.md
@@ -1,0 +1,5 @@
+---
+'@p-j/geocodejson-types': major
+---
+
+BREAKING: changing GeocodeResult.properties.geocoding.housenumber type from string | number to string

--- a/packages/geocodejson-types/index.d.ts
+++ b/packages/geocodejson-types/index.d.ts
@@ -48,7 +48,7 @@ interface GeocodeResult extends Feature {
       name?: string
 
       // OPTIONAL. Housenumber of the place.
-      housenumber?: number | string
+      housenumber?: string
 
       // OPTIONAL. Street of the place.
       street?: string


### PR DESCRIPTION
BREAKING: changing GeocodeResult.properties.geocoding.housenumber type from `string | number` to `string` to make for a cleaner, simpler, more reliable API