### PR TITLE
fix(googleapis): type fixes

### DIFF
--- a/.changeset/curly-swans-cheat.md
+++ b/.changeset/curly-swans-cheat.md
@@ -1,0 +1,6 @@
+---
+'@p-j/geocodejson-googleapis': patch
+---
+
+Recognize the key parameters for getFetchArgs
+Ensure at least one of apiKey and key is given to geocode

--- a/packages/geocodejson-googleapis/src/googleapis.test.ts
+++ b/packages/geocodejson-googleapis/src/googleapis.test.ts
@@ -298,7 +298,7 @@ describe('geocodejson-googleapis', () => {
 
   describe('getFetchArgs', () => {
     it('produce correct argument for a simple search', () => {
-      const params = { address: '1600 Amphitheatre Parkway, Mountain View, CA 94043, USA', key: 'abcabc' } as any
+      const params = { address: '1600 Amphitheatre Parkway, Mountain View, CA 94043, USA', key: 'abcabc' }
 
       const searchParams = new URLSearchParams({
         address: params.address,


### PR DESCRIPTION
Recognize the key parameters for `getFetchArgs`
Ensure at least one of `apiKey` and `key` is given to `geocode`