### PR TITLE
feat(confidence): add confidence score to results

### DIFF
--- a/.changeset/breezy-dots-own.md
+++ b/.changeset/breezy-dots-own.md
@@ -1,0 +1,28 @@
+---
+'@p-j/geocodejson-googleapis': major
+'@p-j/geocodejson-ban': minor
+'@p-j/geocodejson-opencage': minor
+'@p-j/geocodejson-types': minor
+---
+
+# Changelog
+
+Adding `confidence` as an optional member of the `geocoding` namespace
+
+## @p-j/geocodejson-googleapis
+
+**BREAKING:** The `accuracy` member of the `geocoding` namespace has been removed from the parsed result.
+It is replaced by a loosly mapped `confidence` based on the result type.
+
+## @p-j/geocodejson-opencage
+
+- `opencage.parse` return type now provide types for Opencage's specific properties.
+- the confidence is derived from Opencage's confidence score and mapped to a 0-1 interval.
+
+## @p-j/geocodejson-ban
+
+- the confidence is derived from BAN's score.
+
+## @p-j/geocodejson-types
+
+- added the `confidence` optional member to the `geocoding` namespace

--- a/packages/geocodejson-ban/src/geocodejson-ban.test.ts
+++ b/packages/geocodejson-ban/src/geocodejson-ban.test.ts
@@ -32,6 +32,7 @@ describe('@p-j/geocodejson-ban', () => {
                 citycode: '78646',
                 context: '78, Yvelines, Île-de-France',
                 geohash: 'u09t87em7',
+                confidence: 0.7592313152804641,
                 housenumber: '4',
                 id: '78646_1145_00004',
                 importance: 0.69197,
@@ -70,6 +71,7 @@ describe('@p-j/geocodejson-ban', () => {
             geocoding: {
               city: 'Paris',
               citycode: '75111',
+              confidence: 0.9670254545454545,
               context: '75, Paris, Île-de-France',
               district: 'Paris 11e Arrondissement',
               geohash: 'u09tvzfrp',
@@ -109,6 +111,7 @@ describe('@p-j/geocodejson-ban', () => {
             geocoding: {
               city: 'Paris',
               citycode: '75056',
+              confidence: 0.9704590909090908,
               context: '75, Paris, Île-de-France',
               geohash: 'u09tvqt03',
               id: '75056',
@@ -147,6 +150,7 @@ describe('@p-j/geocodejson-ban', () => {
             geocoding: {
               city: 'La Salle-les-Alpes',
               citycode: '05161',
+              confidence: 0.9387145454545454,
               context: "05, Hautes-Alpes, Provence-Alpes-Côte d'Azur",
               geohash: 'spuxtkvf6',
               id: '05161_B193',

--- a/packages/geocodejson-ban/src/geocodejson-ban.ts
+++ b/packages/geocodejson-ban/src/geocodejson-ban.ts
@@ -78,10 +78,15 @@ export function parse(response: BANGeocodeResponse): GeocodeResponse<{}, BANProp
  */
 export function parseResult(result: BANGeocodeResponse['features'][number]): GeocodeFeature<{}, BANProperties> {
   const { properties, ...rest } = result
+
   return {
     ...rest,
     properties: {
-      geocoding: { ...properties, geohash: geohash.encode(rest.geometry.coordinates[1], rest.geometry.coordinates[0]) },
+      geocoding: {
+        ...properties,
+        confidence: properties.score,
+        geohash: geohash.encode(result.geometry.coordinates[1], result.geometry.coordinates[0]),
+      },
     },
   }
 }

--- a/packages/geocodejson-googleapis/src/googleapis.test.ts
+++ b/packages/geocodejson-googleapis/src/googleapis.test.ts
@@ -24,8 +24,9 @@ describe('geocodejson-googleapis', () => {
             type: 'Feature',
             bbox: [-122.0855988802915, 37.4211274197085, -122.0829009197085, 37.4238253802915],
             properties: {
+              pluscode: '849VCWC8+W5',
               geocoding: {
-                accuracy: 10,
+                confidence: 0.9,
                 type: 'house',
                 label: '1600 Amphitheatre Parkway, Mountain View, CA 94043, USA',
                 geohash: '9q9hvuscw',
@@ -61,8 +62,9 @@ describe('geocodejson-googleapis', () => {
             type: 'Feature',
             bbox: [-122.0855988802915, 37.4211274197085, -122.0829009197085, 37.4238253802915],
             properties: {
+              pluscode: '849VCWC8+W5',
               geocoding: {
-                accuracy: 10,
+                confidence: 0.9,
                 type: 'house',
                 label: '1600 Amphitheatre Parkway, Mountain View, CA 94043, USA',
                 geohash: '9q9hvuscw',
@@ -99,7 +101,7 @@ describe('geocodejson-googleapis', () => {
             bbox: [-118.588536, 34.1854649, -118.5534191, 34.2355209],
             properties: {
               geocoding: {
-                accuracy: 1000,
+                confidence: 0.4,
                 type: 'locality',
                 label: 'Winnetka, Los Angeles, CA, USA',
                 geohash: '9q5dtfc1d',
@@ -113,6 +115,7 @@ describe('geocodejson-googleapis', () => {
                 district: undefined,
                 street: undefined,
               },
+              pluscode: undefined,
             },
             geometry: {
               type: 'Point',
@@ -136,7 +139,7 @@ describe('geocodejson-googleapis', () => {
             bbox: [-4.0796176, 39.8383676, -3.9192423, 39.88605099999999],
             properties: {
               geocoding: {
-                accuracy: 1000,
+                confidence: 0.4,
                 type: 'city',
                 label: 'Toledo, Spain',
                 geohash: 'ezj4u2g3u',
@@ -150,6 +153,7 @@ describe('geocodejson-googleapis', () => {
                 street: undefined,
                 postcode: undefined,
               },
+              pluscode: undefined,
             },
             geometry: {
               type: 'Point',
@@ -173,7 +177,7 @@ describe('geocodejson-googleapis', () => {
             bbox: [-16.3370045, 28.4280248, -16.2356646, 28.487616],
             properties: {
               geocoding: {
-                accuracy: 1000,
+                confidence: 0.4,
                 type: 'city',
                 label: 'Santa Cruz de Tenerife, Spain',
                 geohash: 'eth3yjtu8',
@@ -187,6 +191,7 @@ describe('geocodejson-googleapis', () => {
                 street: undefined,
                 postcode: undefined,
               },
+              pluscode: undefined,
             },
             geometry: {
               type: 'Point',
@@ -221,7 +226,7 @@ describe('geocodejson-googleapis', () => {
             bbox: [24.9332897, 60.16226160000001, 24.9433353, 60.168997],
             properties: {
               geocoding: {
-                accuracy: 100,
+                confidence: 0.5,
                 type: 'street',
                 label: 'Annankatu, 00101 Helsinki, Finland',
                 geohash: 'ud9wr2zeh',
@@ -235,6 +240,7 @@ describe('geocodejson-googleapis', () => {
                 state: undefined,
                 county: undefined,
               },
+              pluscode: undefined,
             },
             geometry: {
               type: 'Point',
@@ -258,7 +264,7 @@ describe('geocodejson-googleapis', () => {
             bbox: [0.5906163, 50.8559061, 0.5957329, 50.8601041],
             properties: {
               geocoding: {
-                accuracy: 1000,
+                confidence: 0.3,
                 type: 'street',
                 label: 'High St, Hastings TN34 3EY, UK',
                 geohash: 'u103m6rrj',
@@ -272,6 +278,7 @@ describe('geocodejson-googleapis', () => {
                 locality: undefined,
                 city: undefined,
               },
+              pluscode: undefined,
             },
             geometry: {
               type: 'Point',

--- a/packages/geocodejson-opencage/src/opencage.test.ts
+++ b/packages/geocodejson-opencage/src/opencage.test.ts
@@ -63,6 +63,7 @@ describe('geocodejson-opencage', () => {
               confidence: 9,
               formatted: 'Place de la République, Rue du Temple, 75003 Paris, France',
               geocoding: {
+                confidence: 0.9,
                 type: 'attraction',
                 label: 'Place de la République, Rue du Temple, 75003 Paris, France',
                 geohash: 'u09wjb16h',
@@ -133,6 +134,7 @@ describe('geocodejson-opencage', () => {
               confidence: 10,
               formatted: '4 Rue du Général Leclerc, 78000 Versailles, France',
               geocoding: {
+                confidence: 1,
                 type: 'building',
                 label: '4 Rue du Général Leclerc, 78000 Versailles, France',
                 geohash: 'u09t87ehn',
@@ -171,6 +173,7 @@ describe('geocodejson-opencage', () => {
             },
             properties: {
               geocoding: {
+                confidence: 0.9,
                 type: 'road',
                 label: 'Chemin de Saint-Maurice-de-Gourdans, 01120 Dagneux, France',
                 geohash: 'u05sgdudnf51f70kh05u',

--- a/packages/geocodejson-opencage/src/opencage.ts
+++ b/packages/geocodejson-opencage/src/opencage.ts
@@ -1,4 +1,3 @@
-import type { Feature, Point } from 'geojson'
 import type { GeocodeOptions, GeocodeFeature, GeocodeResponse } from '@p-j/geocodejson-types'
 import type {
   OpenCageGeocodeRequestParams,
@@ -91,7 +90,7 @@ export function getFetchArgs(params: OpenCageGeocodeRequestParams) {
 /**
  * Convert OpenCage GeoJSON response to a GeocodeJSON one
  */
-export function parse(response: OpenCageGeoJSONResponse): GeocodeResponse {
+export function parse(response: OpenCageGeoJSONResponse): GeocodeResponse<OpenCageGeoJSONFeatureProperties> {
   const { query } = response
   return Object.assign(
     {
@@ -113,27 +112,29 @@ export function parse(response: OpenCageGeoJSONResponse): GeocodeResponse {
  * Convert OpenCage GeoJSON feature to a GeocodeJSON one, returning only the necessary properties
  */
 export function parseResult(
-  result: Feature<Point, OpenCageGeoJSONFeatureProperties>,
+  result: OpenCageGeoJSONResponse['features'][number],
 ): GeocodeFeature<OpenCageGeoJSONFeatureProperties> {
+  const { properties, ...rest } = result
   return {
-    ...result,
+    ...rest,
     properties: {
-      ...result.properties,
+      ...properties,
       geocoding: {
-        type: result.properties?.components?._type ?? 'unknown',
-        label: result.properties?.formatted,
+        type: properties.components?._type ?? 'unknown',
+        label: properties.formatted,
         geohash:
-          result.properties?.annotations?.geohash ??
+          properties.annotations?.geohash ??
           geohash.encode(result.geometry.coordinates[1], result.geometry.coordinates[0]),
-        housenumber: result.properties.components?.house_number ?? result.properties.components?.street_number,
-        street: getFirstMatchingKey(ALIASES['street'], result.properties.components),
-        locality: getFirstMatchingKey(ALIASES['locality'], result.properties.components),
-        postcode: getFirstMatchingKey(ALIASES['postcode'], result.properties.components),
-        city: getFirstMatchingKey(ALIASES['city'], result.properties.components),
-        district: getFirstMatchingKey(ALIASES['district'], result.properties.components),
-        county: getFirstMatchingKey(ALIASES['county'], result.properties.components),
-        state: getFirstMatchingKey(ALIASES['state'], result.properties.components),
-        country: getFirstMatchingKey(ALIASES['country'], result.properties.components),
+        housenumber: properties.components?.house_number ?? properties.components?.street_number,
+        street: getFirstMatchingKey(ALIASES['street'], properties.components),
+        locality: getFirstMatchingKey(ALIASES['locality'], properties.components),
+        postcode: getFirstMatchingKey(ALIASES['postcode'], properties.components),
+        city: getFirstMatchingKey(ALIASES['city'], properties.components),
+        district: getFirstMatchingKey(ALIASES['district'], properties.components),
+        county: getFirstMatchingKey(ALIASES['county'], properties.components),
+        state: getFirstMatchingKey(ALIASES['state'], properties.components),
+        country: getFirstMatchingKey(ALIASES['country'], properties.components),
+        confidence: properties.confidence ? properties.confidence / 10 : undefined,
       },
     },
   }

--- a/packages/geocodejson-types/index.d.ts
+++ b/packages/geocodejson-types/index.d.ts
@@ -37,7 +37,12 @@ export interface GeocodeResponse<P = GeoJsonProperties, G = JSONObject>
   }
 }
 
-export type GeocodeFeature<P = GeoJsonProperties, G = JSONObject> = Feature<Point, GeocodeFeatureProperties<G> & P>
+/**
+ * Represent a Geocoding result: it is a Point Feature with
+ * - the specific `geocoding` property
+ * - any inherited properties from the geocode provider, extending either the `properties` (P) or the `properties.geocoding` (G)
+ */
+export type GeocodeFeature<P = GeoJsonProperties, G = JSONObject> = Feature<Point, P & GeocodeFeatureProperties<G>>
 
 export interface GeocodeFeatureProperties<G> extends JSONObject {
   // REQUIRED. Namespace.
@@ -91,6 +96,9 @@ export interface GeocodingProperties extends JSONObject {
 
   // OPTIONAL. Geohash encoding of coordinates (see http://geohash.org/site/tips.html).
   geohash?: string
+
+  // OPTIONAL. ADDITION. A value between 0 and 1 that represente the confidence that the result match the query.
+  confidence?: number
 }
 
 /**


### PR DESCRIPTION
- `confidence` is a value between 0 and 1 that represente the confidence that the result match the query. It is added to the geocoding namespace as an optional member.
- return type of opencage.parse has been imporved and covers opencage's native properties
- google plus code have been added to google's response